### PR TITLE
adds DMG format option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,9 +12,16 @@ const cli = meow(`
 	Usage
 	  $ create-dmg <app>
 
+  Options
+		--format, -f  DMG file format
+
 	Example
 	  $ create-dmg 'Lungo.app'
-`);
+`, {
+	alias: {
+		f: 'format'
+	}
+});
 
 if (process.platform !== 'darwin') {
 	console.error('macOS only');
@@ -44,6 +51,7 @@ const appInfo = plist.parse(infoPlist);
 const appName = appInfo.CFBundleName;
 const appIconName = appInfo.CFBundleIconFile.replace(/\.icns/, '');
 const dmgPath = `${appName.replace(/ /g, '-')}-${appInfo.CFBundleShortVersionString}.dmg`;
+const dmgFormat = cli.flags.format || 'ULFO';
 
 const ora = new Ora('Creating DMG');
 ora.start();
@@ -58,7 +66,7 @@ const ee = appdmg({
 		// https://github.com/LinusU/node-appdmg/issues/135
 		background: path.join(__dirname, 'assets/dmg-background.png'),
 		'icon-size': 160,
-		format: 'ULFO',
+		format: dmgFormat,
 		window: {
 			size: {
 				width: 660,

--- a/test.js
+++ b/test.js
@@ -19,3 +19,21 @@ test(async t => {
 
 	t.true(fs.existsSync(path.join(cwd, 'fixture-0.0.1.dmg')));
 });
+
+test('DMG format option', async t => {
+	const cwd = tempfile();
+	fs.mkdirSync(cwd);
+
+	try {
+		await execa(path.join(__dirname, 'cli.js'), ['-f', 'UDZO', path.join(__dirname, 'fixture.app')], {cwd});
+	} catch (err) {
+		// Silence code signing failure
+		if (!/Code signing failed/.test(err.message)) {
+			throw err;
+		}
+	}
+
+	const fixture = path.join(cwd, 'fixture-0.0.1.dmg');
+	const {stdout} = await execa('hdiutil', ['imageinfo', fixture], {cwd});
+	t.true(stdout.includes('Format: UDZO'));
+});


### PR DESCRIPTION
Would fix #8, tested with hdiutil

`$ create-dmg -f UDZO fixture.app`
```shell
$ hdiutil imageinfo fixture-0.0.1.dmg | grep Format
Format Description: UDIF read-only compressed (zlib)
Format: UDZO
```