### PR TITLE
Add destination directory argument

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,7 @@ const execa = require('execa');
 const cli = meow(`
 	Usage
 	  $ create-dmg <app>
-
+	
 	Example
 	  $ create-dmg 'Lungo.app'
 `);
@@ -28,6 +28,11 @@ if (cli.input.length === 0) {
 
 const appPath = path.resolve(cli.input[0]);
 
+let destPath = ".";
+if (cli.input.length > 1) {
+	destPath = path.resolve(cli.input[1]);
+}
+
 let infoPlist;
 try {
 	infoPlist = fs.readFileSync(path.join(appPath, 'Contents/Info.plist'), 'utf8');
@@ -43,7 +48,7 @@ try {
 const appInfo = plist.parse(infoPlist);
 const appName = appInfo.CFBundleName;
 // `const appIconName = appInfo.CFBundleIconFile.replace(/\.icns/, '');
-const dmgPath = `${appName.replace(/ /g, '-')}-${appInfo.CFBundleShortVersionString}.dmg`;
+const dmgPath = `${destPath}/${appName}-${appInfo.CFBundleShortVersionString}.dmg`;
 
 const ora = new Ora('Creating DMG');
 ora.start();

--- a/cli.js
+++ b/cli.js
@@ -9,11 +9,12 @@ const Ora = require('ora');
 const execa = require('execa');
 
 const cli = meow(`
-	Usage
-	  $ create-dmg <app>
+	Usage:
+	  $ create-dmg <app> [destination]
 	
-	Example
+	Examples:
 	  $ create-dmg 'Lungo.app'
+	  $ create-dmg 'Lungo.app' Build/Releases/
 `);
 
 if (process.platform !== 'darwin') {

--- a/cli.js
+++ b/cli.js
@@ -29,7 +29,7 @@ if (cli.input.length === 0) {
 
 const appPath = path.resolve(cli.input[0]);
 
-let destPath = ".";
+let destPath = '.';
 if (cli.input.length > 1) {
 	destPath = path.resolve(cli.input[1]);
 }

--- a/cli.js
+++ b/cli.js
@@ -49,7 +49,7 @@ try {
 const appInfo = plist.parse(infoPlist);
 const appName = appInfo.CFBundleName;
 // `const appIconName = appInfo.CFBundleIconFile.replace(/\.icns/, '');
-const dmgPath = `${destPath}/${appName}-${appInfo.CFBundleShortVersionString}.dmg`;
+const dmgPath = `${destPath}/${appName} ${appInfo.CFBundleShortVersionString}.dmg`;
 
 const ora = new Ora('Creating DMG');
 ora.start();

--- a/cli.js
+++ b/cli.js
@@ -49,7 +49,7 @@ try {
 const appInfo = plist.parse(infoPlist);
 const appName = appInfo.CFBundleName;
 // `const appIconName = appInfo.CFBundleIconFile.replace(/\.icns/, '');
-const dmgPath = `${destPath}/${appName} ${appInfo.CFBundleShortVersionString}.dmg`;
+const dmgPath = `${appName.replace(/ /g, '-')}-${appInfo.CFBundleShortVersionString}.dmg`;
 
 const ora = new Ora('Creating DMG');
 ora.start();

--- a/readme.md
+++ b/readme.md
@@ -27,11 +27,12 @@ $ npm install --global create-dmg
 ```
 $ create-dmg --help
 
-  Usage
-    $ create-dmg <app>
-
-  Example
-    $ create-dmg 'Lungo.app'
+	Usage:
+	  $ create-dmg <app> [destination]
+	
+	Examples:
+	  $ create-dmg 'Lungo.app'
+	  $ create-dmg 'Lungo.app' Build/Releases/
 ```
 
 


### PR DESCRIPTION
This fixes #12, allowing to enter a second argument to specify a destination directory for the DMG.

Destination directory must already exist.

Only tested it with an unsigned application.

---

This also leaves the appname intact, i.e. it doesn't convert spaces with dashes anymore (doing it afterwards if I don't is __much__ easier than undoing it if I do).