### PR TITLE
Allow use of relative app path

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -70,7 +70,7 @@ if (cli.flags.overwrite) {
 
 const ee = appdmg({
 	target: dmgPath,
-	basepath: __dirname,
+	basepath: process.cwd(),
 	specification: {
 		title: appName,
 		// Disabled because of #16


### PR DESCRIPTION
`__dirname` points to directory of the current module