### PR TITLE
Throw a different error code when code signing fails

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -139,7 +139,7 @@ ee.on('finish', async () => {
 		ora.succeed('DMG created');
 	} catch (error) {
 		ora.fail(`Code signing failed. The DMG is fine, just not code signed.\n${error.stderr.trim()}`);
-		process.exit(1);
+		process.exit(2);
 	}
 });
 


### PR DESCRIPTION
This fixes #24 