### PR TITLE
Fix errors not being printed

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -151,7 +151,7 @@ async function init() {
 	});
 
 	ee.on('error', error => {
-		ora.fail(error);
+		ora.fail(`Building the DMG failed. ${error}`);
 		process.exit(1);
 	});
 }


### PR DESCRIPTION
I encountered this when trying to create a DMG and forgetting the --overwrite flag, but not getting the relevant error message which made me search the source code, since this is what I saw:
![Screenshot 2019-06-05 at 17 06 01](https://user-images.githubusercontent.com/3596182/58968960-30dc0000-87b7-11e9-9a23-75b57d4e5881.png)

After adding the stringed error in the ora.fail, it now prints the error correctly:
![Screenshot 2019-06-05 at 17 06 40](https://user-images.githubusercontent.com/3596182/58968964-33d6f080-87b7-11e9-9b3e-c885cabf7785.png)