### PR TITLE
Allow partial matches for code signing identity

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -162,6 +162,7 @@ async function init() {
 					} else if (
 						[ 'Developer ID Application:',
 						  'Mac Developer:',
+						  'Apple Development:',
 						].some(str => identity.startsWith(str))
 					) {
 						return true

--- a/cli.js
+++ b/cli.js
@@ -150,7 +150,7 @@ async function init() {
 			ora.text = 'Code signing DMG';
 			let identity;
 			const {stdout} = await execa('/usr/bin/security', ['find-identity', '-v', '-p', 'codesigning']);
-			if (cli.flags.identity && stdout.includes(`"${cli.flags.identity}"`)) {
+			if (cli.flags.identity && stdout.includes(cli.flags.identity)) {
 				identity = cli.flags.identity;
 			} else if (!cli.flags.identity && stdout.includes('Developer ID Application:')) {
 				identity = 'Developer ID Application';


### PR DESCRIPTION
The `security find-identity` command spits this out:
```
  1) 9XXXXX304D7307XXXX981678FAXXXX50AA5XXX08 "iPhone Developer: johndoe@example.com (T5X7XXXXMX)"
  2) 0DXXAD187027XXX8ACDXXXXD4C127E46924XXXXX "Apple Development: johndoe@example.com (2XXVHXXL7X)"
     2 valid identities found
```
**Note:** This PR does not account for when 0 valid identities are found. Contribution welcome!

Currently, `create-dmg` wraps the `--identity` flag in double quotes before doing a `.includes` call on the entire stdout. If `true` is returned, the `--identity` flag's value is used as-is.

With this PR, the `--identity` flag is **not** wrapped in quotes, so that partial matches are possible. Then the parsed identity (from `find-identity` stdout) is used, instead of the `--identity` flag's partial value.

**BONUS:** Also included is a commit that adds `Apple Development:` as a value to search for when no `--identity` flag is defined. Perhaps I'm misguided to include this prefix? Curious if you have any insight on that. All I know is, my signing identity starts with that; not `Mac Developer:` or `Developer ID Application:`. 😊 