### PR TITLE
Always generate largest icon

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,7 +7,7 @@ const appdmg = require('appdmg');
 const plist = require('plist');
 const Ora = require('ora');
 const execa = require('execa');
-const addLicenseAgreementIfNeeded = require('./sla.js');
+const addLicenseAgreementIfNeeded = require('./sla');
 const composeIcon = require('./compose-icon');
 
 if (process.platform !== 'darwin') {

--- a/compose-icon.js
+++ b/compose-icon.js
@@ -18,8 +18,11 @@ const biggestPossibleIconType = 'ic10';
 async function composeIcon(type, appIcon, mountIcon, composedIcon) {
 	mountIcon = gm(mountIcon);
 	appIcon = gm(appIcon);
-	const appIconSize = await promisify(appIcon.size.bind(appIcon))();
-	const mountIconSize = await promisify(appIcon.size.bind(mountIcon))();
+
+	const [appIconSize, mountIconSize] = await Promise.all([
+		promisify(appIcon.size.bind(appIcon))(),
+		promisify(appIcon.size.bind(mountIcon))()
+	]);
 
 	// Change the perspective of the app icon to match the mount drive icon
 	appIcon = appIcon.out('-matte').out('-virtual-pixel', 'transparent').out('-distort', 'Perspective', `1,1  ${appIconSize.width * 0.08},1     ${appIconSize.width},1  ${appIconSize.width * 0.92},1     1,${appIconSize.height}  1,${appIconSize.height}     ${appIconSize.width},${appIconSize.height}  ${appIconSize.width},${appIconSize.height}`);

--- a/compose-icon.js
+++ b/compose-icon.js
@@ -13,17 +13,19 @@ const filterMap = (map, filterFn) => Object.entries(map).filter(filterFn).reduce
 // Drive icon from `/System/Library/Extensions/IOStorageFamily.kext/Contents/Resources/Removable.icns``
 const baseDiskIconPath = `${__dirname}/disk-icon.icns`;
 
+const biggestPossibleIconType = 'ic10';
+
 async function composeIcon(type, appIcon, mountIcon, composedIcon) {
 	mountIcon = gm(mountIcon);
 	appIcon = gm(appIcon);
 	const appIconSize = await promisify(appIcon.size.bind(appIcon))();
-	const mountIconSize = appIconSize;
+	const mountIconSize = await promisify(appIcon.size.bind(mountIcon))();
 
 	// Change the perspective of the app icon to match the mount drive icon
 	appIcon = appIcon.out('-matte').out('-virtual-pixel', 'transparent').out('-distort', 'Perspective', `1,1  ${appIconSize.width * 0.08},1     ${appIconSize.width},1  ${appIconSize.width * 0.92},1     1,${appIconSize.height}  1,${appIconSize.height}     ${appIconSize.width},${appIconSize.height}  ${appIconSize.width},${appIconSize.height}`);
 
 	// Resize the app icon to fit it inside the mount icon, aspect ration should not be kept to create the perspective illution
-	appIcon = appIcon.resize(appIconSize.width / 1.7, appIconSize.height / 1.78, '!');
+	appIcon = appIcon.resize(mountIconSize.width / 1.7, mountIconSize.height / 1.78, '!');
 
 	const tempAppIconPath = tempy.file({extension: 'png'});
 	await promisify(appIcon.write.bind(appIcon))(tempAppIconPath);
@@ -64,6 +66,12 @@ module.exports = async appIconPath => {
 
 		console.warn('There is no base image for this type', type);
 	}));
+
+	if (!composedIcon[biggestPossibleIconType]) {
+		// Make sure the highest-resolution variant is generated
+		const largestAppIcon = Object.values(appIcon).sort((a, b) => Buffer.byteLength(b) - Buffer.byteLength(a))[0];
+		await composeIcon(biggestPossibleIconType, largestAppIcon, baseDiskIcons[biggestPossibleIconType], composedIcon);
+	}
 
 	const tempComposedIcon = tempy.file({extension: 'icns'});
 


### PR DESCRIPTION
Should fix #43.

With these changes, create-dmg always generates the biggest possible icon size (`ic10`, 1024 × 1024), even if the source app's icon lacks this size. This makes sure the dmg icon is always nice and sharp.
To generate this large size, the code picks the biggest possible app icon size naively, based on the size of its representing buffer. Things should almost always be good enough!
