### PR TITLE
Add another identifier for detecting code signing identity

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -172,6 +172,8 @@ async function init() {
 				identity = 'Developer ID Application';
 			} else if (!cli.flags.identity && stdout.includes('Mac Developer:')) {
 				identity = 'Mac Developer';
+			} else if (!cli.flags.identity && stdout.includes('Apple Development:')) {
+				identity = 'Apple Development:';
 			}
 
 			if (!identity) {

--- a/cli.js
+++ b/cli.js
@@ -173,7 +173,7 @@ async function init() {
 			} else if (!cli.flags.identity && stdout.includes('Mac Developer:')) {
 				identity = 'Mac Developer';
 			} else if (!cli.flags.identity && stdout.includes('Apple Development:')) {
-				identity = 'Apple Development:';
+				identity = 'Apple Development';
 			}
 
 			if (!identity) {


### PR DESCRIPTION
### Problem:
I am registered in the Apple Developer program, but create-dmg was not detecting my code signing identity. When I run:
```
security find-identity -v -p codesigning
```
my stdout looks something like:
```
  1) XXXXXXXXXXXXXXXXXXXXXXXX "Apple Development: Marwan Hawari (XXXXXXXXXX)"
     1 valid identities found
```

Currently create-dmg looks for `Developer ID Application:` or `Mac Developer:` in the stdout so it was not automatically detecting a valid code signing identity.

### Solution:
This PR allows create-dmg to use `Apple Development:` when automatically detecting if the user has a code signing identity.
With this change, everything works correctly now. I can manually verify that the final dmg was signed using the following (which create-dmg does anyway):
```
codesign ${dmgPath} --display --verbose=2
```

Not sure when Apple started using `Apple Development:` though. For reference, I'm on macOS 13.1 and joined the developer program in 2021. Or maybe I just don't fully understand the code signing identity lol.