### PR TITLE
Create APFS disk images for apps targeting macOS 10.13+

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -111,7 +111,7 @@ async function init() {
 	const majorVersion = Number(minSystemVersionComponents[0]) || 0;
 	const minorVersion = Number(minSystemVersionComponents[1]) || 0;
 	const dmgFormat = (majorVersion > 10 || (majorVersion == 10 && minorVersion >= 11)) ? 'ULFO' : 'UDZO'; // ULFO requires 10.11+
-	const dmgFilesystem = (majorVersion > 10 || (majorVersion == 10 && minorVersion >= 13)) ? 'APFS' : 'HFS+' // APFS requires 10.13+
+	const dmgFilesystem = (majorVersion > 10 || (majorVersion == 10 && minorVersion >= 13)) ? 'APFS' : 'HFS+'; // APFS requires 10.13+
 	ora.info(`Minimum runtime ${minSystemVersion} detected, using ${dmgFormat} format and ${dmgFilesystem} filesystem`).start();
 
 	const ee = appdmg({

--- a/cli.js
+++ b/cli.js
@@ -106,13 +106,9 @@ async function init() {
 		composedIconPath = await composeIcon(path.join(appPath, 'Contents/Resources', `${appIconName}.icns`));
 	}
 
-	const minSystemVersion = (Object.prototype.hasOwnProperty.call(appInfo, 'LSMinimumSystemVersion') && appInfo.LSMinimumSystemVersion.length > 0) ? appInfo.LSMinimumSystemVersion.toString() : '10.11';
-	const minSystemVersionComponents = minSystemVersion.split('.');
-	const majorVersion = Number(minSystemVersionComponents[0]) || 0;
-	const minorVersion = Number(minSystemVersionComponents[1]) || 0;
-	const dmgFormat = (majorVersion > 10 || (majorVersion === 10 && minorVersion >= 11)) ? 'ULFO' : 'UDZO'; // ULFO requires 10.11+
-	const dmgFilesystem = (majorVersion > 10 || (majorVersion === 10 && minorVersion >= 13)) ? 'APFS' : 'HFS+'; // APFS requires 10.13+
-	ora.info(`Minimum runtime ${minSystemVersion} detected, using ${dmgFormat} format and ${dmgFilesystem} filesystem`).start();
+	// Xcode 14+ only supports building apps for macOS 10.13+
+	const dmgFormat = "ULFO" // requires macOS 10.11+
+	const dmgFilesystem = "APFS" // requires macOS 10.13+
 
 	const ee = appdmg({
 		target: dmgPath,

--- a/cli.js
+++ b/cli.js
@@ -107,9 +107,12 @@ async function init() {
 	}
 
 	const minSystemVersion = (Object.prototype.hasOwnProperty.call(appInfo, 'LSMinimumSystemVersion') && appInfo.LSMinimumSystemVersion.length > 0) ? appInfo.LSMinimumSystemVersion.toString() : '10.11';
-	const minorVersion = Number(minSystemVersion.split('.')[1]) || 0;
-	const dmgFormat = (minorVersion >= 11) ? 'ULFO' : 'UDZO'; // ULFO requires 10.11+
-	ora.info(`Minimum runtime ${minSystemVersion} detected, using ${dmgFormat} format`).start();
+	const minSystemVersionComponents = minSystemVersion.split('.');
+	const majorVersion = Number(minSystemVersionComponents[0]) || 0;
+	const minorVersion = Number(minSystemVersionComponents[1]) || 0;
+	const dmgFormat = (majorVersion > 10 || (majorVersion == 10 && minorVersion >= 11)) ? 'ULFO' : 'UDZO'; // ULFO requires 10.11+
+	const dmgFilesystem = (majorVersion > 10 || (majorVersion == 10 && minorVersion >= 13)) ? 'APFS' : 'HFS+' // APFS requires 10.13+
+	ora.info(`Minimum runtime ${minSystemVersion} detected, using ${dmgFormat} format and ${dmgFilesystem} filesystem`).start();
 
 	const ee = appdmg({
 		target: dmgPath,
@@ -123,6 +126,7 @@ async function init() {
 			background: path.join(__dirname, 'assets/dmg-background.png'),
 			'icon-size': 160,
 			format: dmgFormat,
+			filesystem: dmgFilesystem,
 			window: {
 				size: {
 					width: 660,

--- a/cli.js
+++ b/cli.js
@@ -107,8 +107,8 @@ async function init() {
 	}
 
 	// Xcode 14+ only supports building apps for macOS 10.13+
-	const dmgFormat = "ULFO"; // ULFO requires macOS 10.11+
-	const dmgFilesystem = "APFS"; // APFS requires macOS 10.13+
+	const dmgFormat = 'ULFO'; // ULFO requires macOS 10.11+
+	const dmgFilesystem = 'APFS'; // APFS requires macOS 10.13+
 
 	const ee = appdmg({
 		target: dmgPath,

--- a/cli.js
+++ b/cli.js
@@ -107,8 +107,8 @@ async function init() {
 	}
 
 	// Xcode 14+ only supports building apps for macOS 10.13+
-	const dmgFormat = "ULFO" // requires macOS 10.11+
-	const dmgFilesystem = "APFS" // requires macOS 10.13+
+	const dmgFormat = "ULFO"; // ULFO requires macOS 10.11+
+	const dmgFilesystem = "APFS"; // APFS requires macOS 10.13+
 
 	const ee = appdmg({
 		target: dmgPath,

--- a/cli.js
+++ b/cli.js
@@ -110,8 +110,8 @@ async function init() {
 	const minSystemVersionComponents = minSystemVersion.split('.');
 	const majorVersion = Number(minSystemVersionComponents[0]) || 0;
 	const minorVersion = Number(minSystemVersionComponents[1]) || 0;
-	const dmgFormat = (majorVersion > 10 || (majorVersion == 10 && minorVersion >= 11)) ? 'ULFO' : 'UDZO'; // ULFO requires 10.11+
-	const dmgFilesystem = (majorVersion > 10 || (majorVersion == 10 && minorVersion >= 13)) ? 'APFS' : 'HFS+'; // APFS requires 10.13+
+	const dmgFormat = (majorVersion > 10 || (majorVersion === 10 && minorVersion >= 11)) ? 'ULFO' : 'UDZO'; // ULFO requires 10.11+
+	const dmgFilesystem = (majorVersion > 10 || (majorVersion === 10 && minorVersion >= 13)) ? 'APFS' : 'HFS+'; // APFS requires 10.13+
 	ora.info(`Minimum runtime ${minSystemVersion} detected, using ${dmgFormat} format and ${dmgFilesystem} filesystem`).start();
 
 	const ee = appdmg({

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"apple"
 	],
 	"dependencies": {
-		"appdmg": "^0.6.0",
+		"appdmg": "^0.6.6",
 		"execa": "^1.0.0",
 		"gm": "^1.23.1",
 		"icns-lib": "^1.0.1",

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ $ create-dmg --help
 
 ## DMG
 
-The DMG detects the minimum runtime of the app, and uses ULFO (macOS 10.11 or later) or UDZO as appropriate. The resulting image has the filename `App Name 0.0.0.dmg`, for example `Lungo 1.0.0.dmg`.
+The DMG detects the minimum runtime of the app, and uses ULFO (macOS 10.11 or later) and APFS (macOS 10.13 or later) when possible. Otherwise UDZO and HFS+ are used when appropriate. The resulting image has the filename `App Name 0.0.0.dmg`, for example `Lungo 1.0.0.dmg`.
 
 It will try to code sign the DMG, but the DMG is still created and fine even if the code signing fails, for example if you don't have a developer certificate.
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ $ create-dmg --help
 
 ## DMG
 
-The DMG detects the minimum runtime of the app, and uses ULFO (macOS 10.11 or later) and APFS (macOS 10.13 or later) when possible. Otherwise UDZO and HFS+ are used when appropriate. The resulting image has the filename `App Name 0.0.0.dmg`, for example `Lungo 1.0.0.dmg`.
+The DMG requires macOS 10.13 or later and has the filename `App Name 0.0.0.dmg`, for example `Lungo 1.0.0.dmg`.
 
 It will try to code sign the DMG, but the DMG is still created and fine even if the code signing fails, for example if you don't have a developer certificate.
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ $ create-dmg --help
 
 ## DMG
 
-The DMG detects the minimum runtime of the app, and uses LZFSE (macOS 10.11 or later) and APFS (macOS 10.13 or later) when possible. Otherwise zlib and HFS+ are used when appropriate. The resulting image has the filename `App Name 0.0.0.dmg`, for example `Lungo 1.0.0.dmg`.
+The DMG detects the minimum runtime of the app, and uses ULFO (macOS 10.11 or later) and APFS (macOS 10.13 or later) when possible. Otherwise UDZO and HFS+ are used when appropriate. The resulting image has the filename `App Name 0.0.0.dmg`, for example `Lungo 1.0.0.dmg`.
 
 It will try to code sign the DMG, but the DMG is still created and fine even if the code signing fails, for example if you don't have a developer certificate.
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ $ create-dmg --help
 
 ## DMG
 
-The DMG detects the minimum runtime of the app, and uses ULFO (macOS 10.11 or later) and APFS (macOS 10.13 or later) when possible. Otherwise UDZO and HFS+ are used when appropriate. The resulting image has the filename `App Name 0.0.0.dmg`, for example `Lungo 1.0.0.dmg`.
+The DMG detects the minimum runtime of the app, and uses LZFSE (macOS 10.11 or later) and APFS (macOS 10.13 or later) when possible. Otherwise zlib and HFS+ are used when appropriate. The resulting image has the filename `App Name 0.0.0.dmg`, for example `Lungo 1.0.0.dmg`.
 
 It will try to code sign the DMG, but the DMG is still created and fine even if the code signing fails, for example if you don't have a developer certificate.
 


### PR DESCRIPTION
As part of #79, create APFS disk images for macOS 10.13+ apps.

This also fixes a bug where create-dmg may previously prefer to use `UDZO` if the app's minimum system requirement was >= 11.0 because it didn't compare the major version component.

This requires nodeapp-dmg 0.6.6 which I added support for APFS disk images there.