### PR TITLE
Do not validate identity flag to allow for sha1 values

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -162,15 +162,17 @@ async function init() {
 
 			ora.text = 'Code signing DMG';
 			let identity;
-			const {stdout} = await execa('/usr/bin/security', ['find-identity', '-v', '-p', 'codesigning']);
-			if (cli.flags.identity && stdout.includes(`"${cli.flags.identity}"`)) {
+			if (cli.flags.identity) {
 				identity = cli.flags.identity;
-			} else if (!cli.flags.identity && stdout.includes('Developer ID Application:')) {
-				identity = 'Developer ID Application';
-			} else if (!cli.flags.identity && stdout.includes('Mac Developer:')) {
-				identity = 'Mac Developer';
-			} else if (!cli.flags.identity && stdout.includes('Apple Development:')) {
-				identity = 'Apple Development';
+			} else {
+				const {stdout} = await execa('/usr/bin/security', ['find-identity', '-v', '-p', 'codesigning']);
+				if (!cli.flags.identity && stdout.includes('Developer ID Application:')) {
+					identity = 'Developer ID Application';
+				} else if (!cli.flags.identity && stdout.includes('Mac Developer:')) {
+					identity = 'Mac Developer';
+				} else if (!cli.flags.identity && stdout.includes('Apple Development:')) {
+					identity = 'Apple Development';
+				}
 			}
 
 			if (!identity) {

--- a/test.js
+++ b/test.js
@@ -14,7 +14,7 @@ test('main', async t => {
 		await execa(path.join(__dirname, 'cli.js'), ['--identity=0', path.join(__dirname, 'fixtures/Fixture.app')], {cwd});
 	} catch (error) {
 		// Silence code signing failure
-		if (!error.message.includes('No suitable code signing')) {
+		if (!error.message.includes('The specified item could not be found in the keychain')) {
 			throw error;
 		}
 	}
@@ -29,7 +29,7 @@ test('binary plist', async t => {
 		await execa(path.join(__dirname, 'cli.js'), ['--identity=0', path.join(__dirname, 'fixtures/Fixture-with-binary-plist.app')], {cwd});
 	} catch (error) {
 		// Silence code signing failure
-		if (!error.message.includes('No suitable code signing')) {
+		if (!error.message.includes('The specified item could not be found in the keychain')) {
 			throw error;
 		}
 	}
@@ -44,7 +44,7 @@ test('app without icon', async t => {
 		await execa(path.join(__dirname, 'cli.js'), ['--identity=0', path.join(__dirname, 'fixtures/Fixture-no-icon.app')], {cwd});
 	} catch (error) {
 		// Silence code signing failure
-		if (!error.message.includes('No suitable code signing')) {
+		if (!error.message.includes('The specified item could not be found in the keychain')) {
 			throw error;
 		}
 	}


### PR DESCRIPTION
When several code signing identities have the same name, `codesign` will fail:

```bash
security find-identity -v -p codesigning
 1) 3F60B8D9578EAEF1E13A7EEC1394D4CE34139555 "Developer ID Application: App Inc (FR57J8KL90)"
 2) 7952E8BC89E7BF5FCED31AF352783B7A34FADC0D "Developer ID Application: App Inc (FR57J8KL90)"
 
 
create-dmg 'build/myGreatApp.app' 'build/' --identity 'Developer ID Application: App Inc (FR57J8KL90)'
✖ Code signing failed. The DMG is fine, just not code signed.
Developer ID Application: App Inc (FR57J8KL90): ambiguous (matches "Developer ID Application: App Inc (FR57J8KL90)" and "Developer ID Application: App Inc (FR57J8KL90)" in /Users/me/Library/Keychains/login.keychain-db)
```

`codesign` will however work if you give it the matching sha1 for the identity to use.

This change allow to use sha1 as well as identity name by removing the validation for the identity flag that allows for only the name. Not validating seemed fine (instead of validating either possibilities) since codesign will fail when the identity is not valid:

```bash
create-dmg 'build/myGreatApp.app' 'build/' --identity '3F60B8D9578EAEF1E13A7EEC1394D4CE34139555'
ℹ Code signing identity: Developer ID Application: App Inc (FR57J8KL90)
✔ Created “myGreatApp 1.0.0.dmg”

create-dmg 'build/myGreatApp.app' 'build/' --identity 'bad-identity'
✖ Code signing failed. The DMG is fine, just not code signed.
bad-identity: no identity found
```